### PR TITLE
Heading tag Theme changes

### DIFF
--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -1,33 +1,40 @@
 import { createMuiTheme } from '@material-ui/core';
 
+const headerMargin = '10px 0';
+
 export const theme = createMuiTheme({
   typography: {
     fontFamily: '"Roboto"',
     h1: {
       fontSize: '1.7em',
       fontWeight: 'semi-bold',
-      textAlign: 'center'
+      textAlign: 'center',
     },
     h2: {
       fontSize: '2.2em',
       fontWeight: '500',
-      textAlign: 'center'
+      textAlign: 'center',
+      margin: `${headerMargin}`
     },
     h3: {
       fontSize: '1.9em',
-      fontWeight: 'semi-bold'
+      fontWeight: 'semi-bold',
+      margin: `${headerMargin}`
     },
     h4: {
       fontSize: '1.6em',
-      fontWeight: '500'
+      fontWeight: '500',
+      margin: `${headerMargin}`
     },
     h5: {
-      fontSize: '1.3em'
+      fontSize: '1.3em',
+      margin: `${headerMargin}`
     },
     h6: {
       fontSize: '1em',
       fontWeight: '500',
-      textAlign: 'center'
+      textAlign: 'center',
+      margin: `${headerMargin}`
     },
     body1: {
       margin: '10px 0'

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -4,18 +4,25 @@ export const theme = createMuiTheme({
   typography: {
     fontFamily: '"Roboto"',
     h1: {
-      fontSize: '1.5em',
+      fontSize: '1.7em',
       fontWeight: 'semi-bold',
       textAlign: 'center'
     },
     h2: {
-      fontSize: '2.75em',
-      fontWeight: 'semi-bold',
+      fontSize: '2.2em',
+      fontWeight: '500',
       textAlign: 'center'
     },
     h3: {
-      fontSize: '2em',
+      fontSize: '1.9em',
       fontWeight: 'semi-bold'
+    },
+    h4: {
+      fontSize: '1.6em',
+      fontWeight: 'semi-bold'
+    },
+    h5: {
+      fontSize: '1.3em'
     },
     h6: {
       fontSize: '1em',

--- a/client/src/themes/theme.js
+++ b/client/src/themes/theme.js
@@ -19,7 +19,7 @@ export const theme = createMuiTheme({
     },
     h4: {
       fontSize: '1.6em',
-      fontWeight: 'semi-bold'
+      fontWeight: '500'
     },
     h5: {
       fontSize: '1.3em'


### PR DESCRIPTION
I want to make the header tags a bit more consistent in terms of how they are used/look

![image](https://user-images.githubusercontent.com/22737234/69682395-1c8e0700-1066-11ea-8516-e724bbaca4ac.png)

